### PR TITLE
fix: update test_e2e.py path in SQL test workflows

### DIFF
--- a/.github/workflows/sql-tests-free23.yaml
+++ b/.github/workflows/sql-tests-free23.yaml
@@ -58,7 +58,7 @@ jobs:
             WITHPROMETHEUS=1
 
       - name: Generate all fixtures
-        run: cd tests && pytest test_e2e.py -v --tb=short --oracle-env=${{ env.ORACLE_TARGET }}
+        run: cd tests && pytest sql/test_e2e.py -v --tb=short --oracle-env=${{ env.ORACLE_TARGET }}
 
       - name: Upload generated fixtures
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/sql-tests-xe21.yaml
+++ b/.github/workflows/sql-tests-xe21.yaml
@@ -58,7 +58,7 @@ jobs:
             WITHPROMETHEUS=1
 
       - name: Generate all fixtures
-        run: cd tests && pytest test_e2e.py -v --tb=short --oracle-env=${{ env.ORACLE_TARGET }}
+        run: cd tests && pytest sql/test_e2e.py -v --tb=short --oracle-env=${{ env.ORACLE_TARGET }}
 
       - name: Upload generated fixtures
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary
- Fix `test_e2e.py` → `sql/test_e2e.py` in both `sql-tests-free23.yaml` and `sql-tests-xe21.yaml`
- Missed during the directory refactoring in #11

## Test plan
- [x] Path matches actual file location at `tests/sql/test_e2e.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing workflow configurations to adjust test discovery paths across Oracle Database environments, improving test execution reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->