### PR TITLE
feat: add release workflow for tagged builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Release Build
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push release image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.release
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          build-args: |
+            OLR_VERSION=${{ github.ref_name }}
+            UIDOLR=1001
+            GIDOLR=1001
+            GIDORA=54322
+            WITHORACLE=1
+            WITHKAFKA=1
+            WITHPROTOBUF=1
+            WITHPROMETHEUS=1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      contents: read
       packages: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow triggered on `v*` tags
- Builds release image via `Dockerfile.release` and pushes to `ghcr.io/rophy/openlogreplicator:<tag>`
- Uses GITHUB_TOKEN for GHCR auth (no extra secrets needed)

## Test plan
- [ ] Merge PR, push `v1.9.0.1` tag, verify workflow runs and image appears in GHCR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated container image building and publishing workflow for version releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->