### PR TITLE
fix: lowercase GHCR image name in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
     steps:
+      - name: Lowercase image name
+        run: echo "IMAGE=${IMAGE,,}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
@@ -29,7 +34,7 @@ jobs:
           context: .
           file: Dockerfile.release
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: ${{ env.IMAGE }}:${{ github.ref_name }}
           build-args: |
             OLR_VERSION=${{ github.ref_name }}
             UIDOLR=1001


### PR DESCRIPTION
## Summary
- Fix `repository name must be lowercase` error in release workflow
- Lowercase `github.repository` before using as Docker image tag (same pattern as redo-log-tests.yaml)

## Test plan
- [ ] Merge, re-push `v1.9.0.1` tag, verify release build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Docker image tagging process in the release workflow for improved consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rophy/OpenLogReplicator/pull/24)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->