### PR TITLE
feat: support custom OLR image in tests + fix Unicode handling

### DIFF
--- a/tests/dbz-twin/docker-compose.yaml
+++ b/tests/dbz-twin/docker-compose.yaml
@@ -31,6 +31,7 @@ services:
 
   olr:
     image: ${OLR_IMAGE:-olr-dev:latest}
+    user: "${OLR_UID:-1000}:${OLR_GID:-1000}"
     container_name: dbz-olr
     entrypoint: ["/bin/bash", "-c", "mkdir -p /olr-data/checkpoint && exec /opt/OpenLogReplicator/OpenLogReplicator \"$@\"", "--"]
     command: ["-r", "-f", "/config/olr-config.json"]

--- a/tests/dbz-twin/docker-compose.yaml
+++ b/tests/dbz-twin/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - ./output:/app/output
 
   olr:
-    image: olr-dev:${OLR_IMAGE_TAG:-latest}
+    image: ${OLR_IMAGE:-olr-dev:latest}
     container_name: dbz-olr
     entrypoint: ["/bin/bash", "-c", "mkdir -p /olr-data/checkpoint && exec /opt/OpenLogReplicator/OpenLogReplicator \"$@\"", "--"]
     command: ["-r", "-f", "/config/olr-config.json"]

--- a/tests/environments/enterprise-19/docker-compose.yaml
+++ b/tests/environments/enterprise-19/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   olr:
-    image: olr-dev:${OLR_IMAGE_TAG:-latest}
+    image: ${OLR_IMAGE:-olr-dev:latest}
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/enterprise-19/docker-compose.yaml
+++ b/tests/environments/enterprise-19/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   olr:
     image: ${OLR_IMAGE:-olr-dev:latest}
+    user: "${OLR_UID:-1000}:${OLR_GID:-1000}"
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/free-23/docker-compose.yaml
+++ b/tests/environments/free-23/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   olr:
-    image: olr-dev:${OLR_IMAGE_TAG:-latest}
+    image: ${OLR_IMAGE:-olr-dev:latest}
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/free-23/docker-compose.yaml
+++ b/tests/environments/free-23/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   olr:
     image: ${OLR_IMAGE:-olr-dev:latest}
+    user: "${OLR_UID:-1000}:${OLR_GID:-1000}"
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/xe-21-official/docker-compose.yaml
+++ b/tests/environments/xe-21-official/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   olr:
-    image: olr-dev:${OLR_IMAGE_TAG:-latest}
+    image: ${OLR_IMAGE:-olr-dev:latest}
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/xe-21-official/docker-compose.yaml
+++ b/tests/environments/xe-21-official/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   olr:
     image: ${OLR_IMAGE:-olr-dev:latest}
+    user: "${OLR_UID:-1000}:${OLR_GID:-1000}"
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/xe-21/docker-compose.yaml
+++ b/tests/environments/xe-21/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   olr:
-    image: olr-dev:${OLR_IMAGE_TAG:-latest}
+    image: ${OLR_IMAGE:-olr-dev:latest}
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/environments/xe-21/docker-compose.yaml
+++ b/tests/environments/xe-21/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   olr:
     image: ${OLR_IMAGE:-olr-dev:latest}
+    user: "${OLR_UID:-1000}:${OLR_GID:-1000}"
     entrypoint: []
     command: ["sleep", "infinity"]
     volumes:

--- a/tests/fixtures/test_fixtures.py
+++ b/tests/fixtures/test_fixtures.py
@@ -24,6 +24,7 @@ def _run_olr(config_path, tmp_dir):
     return subprocess.run(
         [
             "docker", "run", "--rm",
+            "--user", f"{os.getuid()}:{os.getgid()}",
             "-v", f"{tmp_dir}:/olr-work",
             "-v", f"{TESTS_DIR}:/tests:ro",
             "--entrypoint", "/opt/OpenLogReplicator/OpenLogReplicator",

--- a/tests/sql/scripts/drivers/base.sh
+++ b/tests/sql/scripts/drivers/base.sh
@@ -33,6 +33,10 @@
 # Container path prefix — tests/ is mounted here inside OLR container
 _CONTAINER_TESTS="${_CONTAINER_TESTS:-/opt/OpenLogReplicator-local/tests}"
 
+# Export UID/GID so docker-compose can set user: on the olr service
+export OLR_UID="$(id -u)"
+export OLR_GID="$(id -g)"
+
 # ---- Overridable hook ----
 patch_gencfg() { :; }
 

--- a/tests/sql/scripts/drivers/docker.sh
+++ b/tests/sql/scripts/drivers/docker.sh
@@ -12,9 +12,9 @@ source "$SCRIPT_DIR/drivers/base.sh"
 
 : "${ORACLE_CONTAINER:=oracle}"
 
-_DEXEC="docker exec"
+_DEXEC="docker exec -e NLS_LANG=AMERICAN_AMERICA.AL32UTF8"
 if [[ -n "${DOCKER_EXEC_USER:-}" ]]; then
-    _DEXEC="docker exec -u $DOCKER_EXEC_USER"
+    _DEXEC="docker exec -e NLS_LANG=AMERICAN_AMERICA.AL32UTF8 -u $DOCKER_EXEC_USER"
 fi
 
 _OLR_BINARY="/opt/OpenLogReplicator/OpenLogReplicator"


### PR DESCRIPTION
## Summary
- Allow overriding OLR image via `OLR_IMAGE` env var in all docker-compose files (enables testing release images like `ghcr.io/rophy/openlogreplicator:v1.9.0.1`)
- Add `--user` to docker run in redo log tests for release image compatibility (release image runs as UID 1001)
- Add `user:` override in compose services, exported from base driver
- Fix `NLS_LANG=AMERICAN_AMERICA.AL32UTF8` in docker exec calls — enterprise-19 defaulted to US7ASCII, corrupting Unicode in LogMiner output

## Test plan
- [x] Redo log tests: 161/161 passed (release image)
- [x] SQL e2e free-23: 36 passed, 20 skipped (release image)
- [x] SQL e2e xe-21: 36 passed, 20 skipped (release image)
- [x] SQL e2e enterprise-19: 36 passed, 20 skipped (release image, nchar-nclob now passes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker container configurations to support environment-variable-driven customization for container images and runtime user/group settings across test environments.
  * Updated test execution scripts to explicitly configure database locale settings and export user/group identifiers for consistent container execution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rophy/OpenLogReplicator/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->